### PR TITLE
Add app_id field

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,9 +51,8 @@ jobs:
       fail-fast: false
       matrix:
         terraform:
-          - '0.13.7'
           - '0.14.11'
-          - '0.15.1'
+          - '0.15.5'
     steps:
 
     - name: Set up Go

--- a/docs/data-sources/index.md
+++ b/docs/data-sources/index.md
@@ -27,6 +27,7 @@ data "algolia_index" "example" {
 
 ### Optional
 
+- **app_id** (String) The ID of the app in which the resource belongs. If it is not provided, the provider app_id is used.
 - **id** (String) The ID of this resource.
 
 ### Read-Only

--- a/docs/resources/api_key.md
+++ b/docs/resources/api_key.md
@@ -48,6 +48,7 @@ The possible ACLs are:
 
 ### Optional
 
+- **app_id** (String) The ID of the app in which the resource belongs. If it is not provided, the provider app_id is used.
 - **description** (String) Description of the API key.
 - **expires_at** (String) Unix timestamp of the date at which the key expires. RFC3339 format. Will not expire per default.
 - **id** (String) The ID of this resource.

--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -63,6 +63,7 @@ resource "algolia_index" "example" {
 
 ### Optional
 
+- **app_id** (String) The ID of the app in which the resource belongs. If it is not provided, the provider app_id is used.
 - **attributes_config** (Block List, Max: 1) The configuration for attributes. (see [below for nested schema](#nestedblock--attributes_config))
 - **enable_personalization** (Boolean) Weather to enable the Personalization feature.
 - **enable_rules** (Boolean) Whether Rules should be globally enabled.

--- a/docs/resources/rule.md
+++ b/docs/resources/rule.md
@@ -49,6 +49,7 @@ At least one of the following object must be used:
 
 ### Optional
 
+- **app_id** (String) The ID of the app in which the resource belongs. If it is not provided, the provider app_id is used.
 - **conditions** (Block List) A list of conditions that should apply to activate a Rule. You can use up to 25 conditions per Rule. (see [below for nested schema](#nestedblock--conditions))
 - **description** (String) This field is intended for Rule management purposes, in particular to ease searching for Rules and presenting them to human readers. It is not interpreted by the API.
 - **enabled** (Boolean) Whether the Rule is enabled. Disabled Rules remain in the index, but are not applied at query time.

--- a/docs/resources/synonyms.md
+++ b/docs/resources/synonyms.md
@@ -25,6 +25,7 @@ A configuration for synonyms. To get more information about synonyms, see the [O
 
 ### Optional
 
+- **app_id** (String) The ID of the app in which the resource belongs. If it is not provided, the provider app_id is used.
 - **id** (String) The ID of this resource.
 
 <a id="nestedblock--synonyms"></a>

--- a/internal/provider/data_source_index.go
+++ b/internal/provider/data_source_index.go
@@ -12,6 +12,12 @@ func dataSourceIndex() *schema.Resource {
 		ReadContext: dataSourceIndexRead,
 		// https://www.algolia.com/doc/api-reference/settings-api-parameters/
 		Schema: map[string]*schema.Schema{
+			"app_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The ID of the app in which the resource belongs. If it is not provided, the provider app_id is used.",
+			},
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -47,7 +47,7 @@ func New(version string) func() *schema.Provider {
 }
 
 type apiClient struct {
-	searchClient *search.Client
+	searchConfig search.Configuration
 }
 
 func configure(version string, p *schema.Provider) func(context.Context, *schema.ResourceData) (interface{}, diag.Diagnostics) {
@@ -57,8 +57,16 @@ func configure(version string, p *schema.Provider) func(context.Context, *schema
 			APIKey:         d.Get("api_key").(string),
 			ExtraUserAgent: p.UserAgent("terraform-provider-algolia", version),
 		}
-		algoliaClient := search.NewClientWithConfig(config)
 
-		return &apiClient{searchClient: algoliaClient}, nil
+		return &apiClient{
+			searchConfig: config,
+		}, nil
 	}
+}
+
+func newSearchClient(searchConfig search.Configuration, d *schema.ResourceData) *search.Client {
+	if appID, ok := d.GetOk("app_id"); ok {
+		searchConfig.AppID = appID.(string)
+	}
+	return search.NewClientWithConfig(searchConfig)
 }

--- a/internal/provider/resource_api_key.go
+++ b/internal/provider/resource_api_key.go
@@ -22,6 +22,12 @@ func resourceAPIKey() *schema.Resource {
 		Description: "A configuration for an API key",
 		// https://www.algolia.com/doc/api-reference/api-methods/add-api-key/
 		Schema: map[string]*schema.Schema{
+			"app_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The ID of the app in which the resource belongs. If it is not provided, the provider app_id is used.",
+			},
 			"key": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -100,9 +106,9 @@ This parameter can be used to protect you from attempts at retrieving your entir
 }
 
 func resourceAPIKeyCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	apiClient := m.(*apiClient)
+	searchClient := newSearchClient(m.(*apiClient).searchConfig, d)
 
-	res, err := apiClient.searchClient.AddAPIKey(mapToAPIKey(d), ctx)
+	res, err := searchClient.AddAPIKey(mapToAPIKey(d), ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -125,9 +131,9 @@ func resourceAPIKeyRead(ctx context.Context, d *schema.ResourceData, m interface
 }
 
 func resourceAPIKeyUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	apiClient := m.(*apiClient)
+	searchClient := newSearchClient(m.(*apiClient).searchConfig, d)
 
-	res, err := apiClient.searchClient.UpdateAPIKey(mapToAPIKey(d), ctx)
+	res, err := searchClient.UpdateAPIKey(mapToAPIKey(d), ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -139,9 +145,9 @@ func resourceAPIKeyUpdate(ctx context.Context, d *schema.ResourceData, m interfa
 }
 
 func resourceAPIKeyDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	apiClient := m.(*apiClient)
+	searchClient := newSearchClient(m.(*apiClient).searchConfig, d)
 
-	res, err := apiClient.searchClient.DeleteAPIKey(d.Get("key").(string), ctx)
+	res, err := searchClient.DeleteAPIKey(d.Get("key").(string), ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -165,10 +171,10 @@ func resourceAPIKeyStateContext(ctx context.Context, d *schema.ResourceData, m i
 }
 
 func refreshAPIKeyState(ctx context.Context, d *schema.ResourceData, m interface{}) error {
-	apiClient := m.(*apiClient)
+	searchClient := newSearchClient(m.(*apiClient).searchConfig, d)
 
 	keyID := d.Get("key").(string)
-	key, err := apiClient.searchClient.GetAPIKey(keyID, ctx)
+	key, err := searchClient.GetAPIKey(keyID, ctx)
 	if err != nil {
 		d.SetId("")
 		return err

--- a/internal/provider/resource_rule.go
+++ b/internal/provider/resource_rule.go
@@ -25,6 +25,12 @@ func resourceRule() *schema.Resource {
 		Description: "A configuration for a Rule.  To get more information about rules, see the [Official Documentation](https://www.algolia.com/doc/guides/managing-results/rules/rules-overview/).",
 		// https://www.algolia.com/doc/api-reference/api-methods/save-rule/#parameters
 		Schema: map[string]*schema.Schema{
+			"app_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The ID of the app in which the resource belongs. If it is not provided, the provider app_id is used.",
+			},
 			"index_name": {
 				Type:        schema.TypeString,
 				Required:    true,
@@ -272,11 +278,11 @@ At least one of the following object must be used:
 }
 
 func resourceRuleCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	apiClient := m.(*apiClient)
+	searchClient := newSearchClient(m.(*apiClient).searchConfig, d)
 
 	rule := mapToRule(d)
 
-	index := apiClient.searchClient.InitIndex(d.Get("index_name").(string))
+	index := searchClient.InitIndex(d.Get("index_name").(string))
 	res, err := index.SaveRule(rule, ctx)
 	if err != nil {
 		return diag.FromErr(err)
@@ -298,11 +304,11 @@ func resourceRuleRead(ctx context.Context, d *schema.ResourceData, m interface{}
 }
 
 func resourceRuleUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	apiClient := m.(*apiClient)
+	searchClient := newSearchClient(m.(*apiClient).searchConfig, d)
 
 	rule := mapToRule(d)
 
-	index := apiClient.searchClient.InitIndex(d.Get("index_name").(string))
+	index := searchClient.InitIndex(d.Get("index_name").(string))
 	res, err := index.SaveRule(rule, ctx)
 	if err != nil {
 		return diag.FromErr(err)
@@ -317,9 +323,9 @@ func resourceRuleUpdate(ctx context.Context, d *schema.ResourceData, m interface
 }
 
 func resourceRuleDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	apiClient := m.(*apiClient)
+	searchClient := newSearchClient(m.(*apiClient).searchConfig, d)
 
-	index := apiClient.searchClient.InitIndex(d.Get("index_name").(string))
+	index := searchClient.InitIndex(d.Get("index_name").(string))
 	res, err := index.DeleteRule(d.Get("object_id").(string), ctx)
 	if err != nil {
 		return diag.FromErr(err)
@@ -352,10 +358,10 @@ func resourceRuleStateContext(ctx context.Context, d *schema.ResourceData, m int
 }
 
 func refreshRuleState(ctx context.Context, d *schema.ResourceData, m interface{}) error {
-	apiClient := m.(*apiClient)
+	searchClient := newSearchClient(m.(*apiClient).searchConfig, d)
 
 	indexName := d.Get("index_name").(string)
-	index := apiClient.searchClient.InitIndex(indexName)
+	index := searchClient.InitIndex(indexName)
 
 	rule, err := index.GetRule(d.Id(), ctx)
 	if err != nil {

--- a/internal/provider/testutils.go
+++ b/internal/provider/testutils.go
@@ -18,12 +18,10 @@ func testCheckResourceListAttr(name, key string, values []string) resource.TestC
 
 // The first character must be alphabet for algolia resources
 func randStringStartWithAlpha(length int) string {
-	const uuidLen = 21 // firstChar + xid(20 chars)
 	uuid := acctest.RandStringFromCharSet(1, acctest.CharSetAlpha) + xid.New().String()
-
-	if length < uuidLen {
+	if length < len(uuid) {
 		return uuid[:length]
 	}
 
-	return uuid + acctest.RandStringFromCharSet(length-uuidLen, acctest.CharSetAlphaNum)
+	return uuid + acctest.RandStringFromCharSet(length-len(uuid), acctest.CharSetAlphaNum)
 }


### PR DESCRIPTION
Make it possible to set `app_id` to each resource.
If `app_id` is not set, the provider's `app_id` will be used.