### PR TITLE
Revert "Add app_id field"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,8 +51,9 @@ jobs:
       fail-fast: false
       matrix:
         terraform:
+          - '0.13.7'
           - '0.14.11'
-          - '0.15.5'
+          - '0.15.1'
     steps:
 
     - name: Set up Go

--- a/docs/data-sources/index.md
+++ b/docs/data-sources/index.md
@@ -27,7 +27,6 @@ data "algolia_index" "example" {
 
 ### Optional
 
-- **app_id** (String) The ID of the app in which the resource belongs. If it is not provided, the provider app_id is used.
 - **id** (String) The ID of this resource.
 
 ### Read-Only

--- a/docs/resources/api_key.md
+++ b/docs/resources/api_key.md
@@ -48,7 +48,6 @@ The possible ACLs are:
 
 ### Optional
 
-- **app_id** (String) The ID of the app in which the resource belongs. If it is not provided, the provider app_id is used.
 - **description** (String) Description of the API key.
 - **expires_at** (String) Unix timestamp of the date at which the key expires. RFC3339 format. Will not expire per default.
 - **id** (String) The ID of this resource.

--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -63,7 +63,6 @@ resource "algolia_index" "example" {
 
 ### Optional
 
-- **app_id** (String) The ID of the app in which the resource belongs. If it is not provided, the provider app_id is used.
 - **attributes_config** (Block List, Max: 1) The configuration for attributes. (see [below for nested schema](#nestedblock--attributes_config))
 - **enable_personalization** (Boolean) Weather to enable the Personalization feature.
 - **enable_rules** (Boolean) Whether Rules should be globally enabled.

--- a/docs/resources/rule.md
+++ b/docs/resources/rule.md
@@ -49,7 +49,6 @@ At least one of the following object must be used:
 
 ### Optional
 
-- **app_id** (String) The ID of the app in which the resource belongs. If it is not provided, the provider app_id is used.
 - **conditions** (Block List) A list of conditions that should apply to activate a Rule. You can use up to 25 conditions per Rule. (see [below for nested schema](#nestedblock--conditions))
 - **description** (String) This field is intended for Rule management purposes, in particular to ease searching for Rules and presenting them to human readers. It is not interpreted by the API.
 - **enabled** (Boolean) Whether the Rule is enabled. Disabled Rules remain in the index, but are not applied at query time.

--- a/docs/resources/synonyms.md
+++ b/docs/resources/synonyms.md
@@ -25,7 +25,6 @@ A configuration for synonyms. To get more information about synonyms, see the [O
 
 ### Optional
 
-- **app_id** (String) The ID of the app in which the resource belongs. If it is not provided, the provider app_id is used.
 - **id** (String) The ID of this resource.
 
 <a id="nestedblock--synonyms"></a>

--- a/internal/provider/data_source_index.go
+++ b/internal/provider/data_source_index.go
@@ -12,12 +12,6 @@ func dataSourceIndex() *schema.Resource {
 		ReadContext: dataSourceIndexRead,
 		// https://www.algolia.com/doc/api-reference/settings-api-parameters/
 		Schema: map[string]*schema.Schema{
-			"app_id": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				ForceNew:    true,
-				Description: "The ID of the app in which the resource belongs. If it is not provided, the provider app_id is used.",
-			},
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -47,7 +47,7 @@ func New(version string) func() *schema.Provider {
 }
 
 type apiClient struct {
-	searchConfig search.Configuration
+	searchClient *search.Client
 }
 
 func configure(version string, p *schema.Provider) func(context.Context, *schema.ResourceData) (interface{}, diag.Diagnostics) {
@@ -57,16 +57,8 @@ func configure(version string, p *schema.Provider) func(context.Context, *schema
 			APIKey:         d.Get("api_key").(string),
 			ExtraUserAgent: p.UserAgent("terraform-provider-algolia", version),
 		}
+		algoliaClient := search.NewClientWithConfig(config)
 
-		return &apiClient{
-			searchConfig: config,
-		}, nil
+		return &apiClient{searchClient: algoliaClient}, nil
 	}
-}
-
-func newSearchClient(searchConfig search.Configuration, d *schema.ResourceData) *search.Client {
-	if appID, ok := d.GetOk("app_id"); ok {
-		searchConfig.AppID = appID.(string)
-	}
-	return search.NewClientWithConfig(searchConfig)
 }

--- a/internal/provider/resource_api_key.go
+++ b/internal/provider/resource_api_key.go
@@ -22,12 +22,6 @@ func resourceAPIKey() *schema.Resource {
 		Description: "A configuration for an API key",
 		// https://www.algolia.com/doc/api-reference/api-methods/add-api-key/
 		Schema: map[string]*schema.Schema{
-			"app_id": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				ForceNew:    true,
-				Description: "The ID of the app in which the resource belongs. If it is not provided, the provider app_id is used.",
-			},
 			"key": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -106,9 +100,9 @@ This parameter can be used to protect you from attempts at retrieving your entir
 }
 
 func resourceAPIKeyCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	searchClient := newSearchClient(m.(*apiClient).searchConfig, d)
+	apiClient := m.(*apiClient)
 
-	res, err := searchClient.AddAPIKey(mapToAPIKey(d), ctx)
+	res, err := apiClient.searchClient.AddAPIKey(mapToAPIKey(d), ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -131,9 +125,9 @@ func resourceAPIKeyRead(ctx context.Context, d *schema.ResourceData, m interface
 }
 
 func resourceAPIKeyUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	searchClient := newSearchClient(m.(*apiClient).searchConfig, d)
+	apiClient := m.(*apiClient)
 
-	res, err := searchClient.UpdateAPIKey(mapToAPIKey(d), ctx)
+	res, err := apiClient.searchClient.UpdateAPIKey(mapToAPIKey(d), ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -145,9 +139,9 @@ func resourceAPIKeyUpdate(ctx context.Context, d *schema.ResourceData, m interfa
 }
 
 func resourceAPIKeyDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	searchClient := newSearchClient(m.(*apiClient).searchConfig, d)
+	apiClient := m.(*apiClient)
 
-	res, err := searchClient.DeleteAPIKey(d.Get("key").(string), ctx)
+	res, err := apiClient.searchClient.DeleteAPIKey(d.Get("key").(string), ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -171,10 +165,10 @@ func resourceAPIKeyStateContext(ctx context.Context, d *schema.ResourceData, m i
 }
 
 func refreshAPIKeyState(ctx context.Context, d *schema.ResourceData, m interface{}) error {
-	searchClient := newSearchClient(m.(*apiClient).searchConfig, d)
+	apiClient := m.(*apiClient)
 
 	keyID := d.Get("key").(string)
-	key, err := searchClient.GetAPIKey(keyID, ctx)
+	key, err := apiClient.searchClient.GetAPIKey(keyID, ctx)
 	if err != nil {
 		d.SetId("")
 		return err

--- a/internal/provider/resource_index.go
+++ b/internal/provider/resource_index.go
@@ -22,12 +22,6 @@ func resourceIndex() *schema.Resource {
 		Description: "A configuration for an index.",
 		// https://www.algolia.com/doc/api-reference/settings-api-parameters/
 		Schema: map[string]*schema.Schema{
-			"app_id": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				ForceNew:    true,
-				Description: "The ID of the app in which the resource belongs. If it is not provided, the provider app_id is used.",
-			},
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
@@ -502,10 +496,10 @@ List of supported languages are listed on http://nhttps//www.algolia.com/doc/api
 }
 
 func resourceIndexCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	searchClient := newSearchClient(m.(*apiClient).searchConfig, d)
+	apiClient := m.(*apiClient)
 
 	indexName := d.Get("name").(string)
-	index := searchClient.InitIndex(indexName)
+	index := apiClient.searchClient.InitIndex(indexName)
 	res, err := index.SetSettings(mapToIndexSettings(d))
 	if err != nil {
 		return diag.FromErr(err)
@@ -527,9 +521,9 @@ func resourceIndexRead(ctx context.Context, d *schema.ResourceData, m interface{
 }
 
 func resourceIndexUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	searchClient := newSearchClient(m.(*apiClient).searchConfig, d)
+	apiClient := m.(*apiClient)
 
-	index := searchClient.InitIndex(d.Id())
+	index := apiClient.searchClient.InitIndex(d.Id())
 	res, err := index.SetSettings(mapToIndexSettings(d))
 	if err != nil {
 		return diag.FromErr(err)
@@ -542,9 +536,9 @@ func resourceIndexUpdate(ctx context.Context, d *schema.ResourceData, m interfac
 }
 
 func resourceIndexDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	searchClient := newSearchClient(m.(*apiClient).searchConfig, d)
+	apiClient := m.(*apiClient)
 
-	index := searchClient.InitIndex(d.Id())
+	index := apiClient.searchClient.InitIndex(d.Id())
 	res, err := index.Delete(ctx)
 	if err != nil {
 		return diag.FromErr(err)
@@ -565,9 +559,9 @@ func resourceIndexStateContext(ctx context.Context, d *schema.ResourceData, m in
 }
 
 func refreshIndexState(ctx context.Context, d *schema.ResourceData, m interface{}) error {
-	searchClient := newSearchClient(m.(*apiClient).searchConfig, d)
+	apiClient := m.(*apiClient)
 
-	index := searchClient.InitIndex(d.Id())
+	index := apiClient.searchClient.InitIndex(d.Id())
 	settings, err := index.GetSettings(ctx)
 	if err != nil {
 		d.SetId("")

--- a/internal/provider/resource_rule.go
+++ b/internal/provider/resource_rule.go
@@ -25,12 +25,6 @@ func resourceRule() *schema.Resource {
 		Description: "A configuration for a Rule.  To get more information about rules, see the [Official Documentation](https://www.algolia.com/doc/guides/managing-results/rules/rules-overview/).",
 		// https://www.algolia.com/doc/api-reference/api-methods/save-rule/#parameters
 		Schema: map[string]*schema.Schema{
-			"app_id": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				ForceNew:    true,
-				Description: "The ID of the app in which the resource belongs. If it is not provided, the provider app_id is used.",
-			},
 			"index_name": {
 				Type:        schema.TypeString,
 				Required:    true,
@@ -278,11 +272,11 @@ At least one of the following object must be used:
 }
 
 func resourceRuleCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	searchClient := newSearchClient(m.(*apiClient).searchConfig, d)
+	apiClient := m.(*apiClient)
 
 	rule := mapToRule(d)
 
-	index := searchClient.InitIndex(d.Get("index_name").(string))
+	index := apiClient.searchClient.InitIndex(d.Get("index_name").(string))
 	res, err := index.SaveRule(rule, ctx)
 	if err != nil {
 		return diag.FromErr(err)
@@ -304,11 +298,11 @@ func resourceRuleRead(ctx context.Context, d *schema.ResourceData, m interface{}
 }
 
 func resourceRuleUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	searchClient := newSearchClient(m.(*apiClient).searchConfig, d)
+	apiClient := m.(*apiClient)
 
 	rule := mapToRule(d)
 
-	index := searchClient.InitIndex(d.Get("index_name").(string))
+	index := apiClient.searchClient.InitIndex(d.Get("index_name").(string))
 	res, err := index.SaveRule(rule, ctx)
 	if err != nil {
 		return diag.FromErr(err)
@@ -323,9 +317,9 @@ func resourceRuleUpdate(ctx context.Context, d *schema.ResourceData, m interface
 }
 
 func resourceRuleDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	searchClient := newSearchClient(m.(*apiClient).searchConfig, d)
+	apiClient := m.(*apiClient)
 
-	index := searchClient.InitIndex(d.Get("index_name").(string))
+	index := apiClient.searchClient.InitIndex(d.Get("index_name").(string))
 	res, err := index.DeleteRule(d.Get("object_id").(string), ctx)
 	if err != nil {
 		return diag.FromErr(err)
@@ -358,10 +352,10 @@ func resourceRuleStateContext(ctx context.Context, d *schema.ResourceData, m int
 }
 
 func refreshRuleState(ctx context.Context, d *schema.ResourceData, m interface{}) error {
-	searchClient := newSearchClient(m.(*apiClient).searchConfig, d)
+	apiClient := m.(*apiClient)
 
 	indexName := d.Get("index_name").(string)
-	index := searchClient.InitIndex(indexName)
+	index := apiClient.searchClient.InitIndex(indexName)
 
 	rule, err := index.GetRule(d.Id(), ctx)
 	if err != nil {

--- a/internal/provider/resource_synonyms.go
+++ b/internal/provider/resource_synonyms.go
@@ -24,12 +24,6 @@ func resourceSynonyms() *schema.Resource {
 `,
 		// https://www.algolia.com/doc/api-reference/api-methods/batch-synonyms/
 		Schema: map[string]*schema.Schema{
-			"app_id": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				ForceNew:    true,
-				Description: "The ID of the app in which the resource belongs. If it is not provided, the provider app_id is used.",
-			},
 			"index_name": {
 				Type:        schema.TypeString,
 				Required:    true,
@@ -94,10 +88,10 @@ func resourceSynonyms() *schema.Resource {
 }
 
 func resourceSynonymsCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	searchClient := newSearchClient(m.(*apiClient).searchConfig, d)
+	apiClient := m.(*apiClient)
 
 	indexName := d.Get("index_name").(string)
-	res, err := searchClient.InitIndex(indexName).ReplaceAllSynonyms(mapToSynonyms(d), ctx)
+	res, err := apiClient.searchClient.InitIndex(indexName).ReplaceAllSynonyms(mapToSynonyms(d), ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -118,10 +112,10 @@ func resourceSynonymsRead(ctx context.Context, d *schema.ResourceData, m interfa
 }
 
 func resourceSynonymsUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	searchClient := newSearchClient(m.(*apiClient).searchConfig, d)
+	apiClient := m.(*apiClient)
 
 	indexName := d.Get("index_name").(string)
-	res, err := searchClient.InitIndex(indexName).ReplaceAllSynonyms(mapToSynonyms(d), ctx)
+	res, err := apiClient.searchClient.InitIndex(indexName).ReplaceAllSynonyms(mapToSynonyms(d), ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -135,9 +129,9 @@ func resourceSynonymsUpdate(ctx context.Context, d *schema.ResourceData, m inter
 }
 
 func resourceSynonymsDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	searchClient := newSearchClient(m.(*apiClient).searchConfig, d)
+	apiClient := m.(*apiClient)
 
-	res, err := searchClient.InitIndex(d.Id()).ClearSynonyms(ctx)
+	res, err := apiClient.searchClient.InitIndex(d.Id()).ClearSynonyms(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -160,11 +154,11 @@ func resourceSynonymsStateContext(ctx context.Context, d *schema.ResourceData, m
 }
 
 func refreshSynonymsState(ctx context.Context, d *schema.ResourceData, m interface{}) error {
-	searchClient := newSearchClient(m.(*apiClient).searchConfig, d)
+	apiClient := m.(*apiClient)
 
 	indexName := d.Get("index_name").(string)
 
-	iter, err := searchClient.InitIndex(indexName).BrowseSynonyms(ctx)
+	iter, err := apiClient.searchClient.InitIndex(indexName).BrowseSynonyms(ctx)
 	if err != nil {
 		d.SetId("")
 		return err

--- a/internal/provider/testutils.go
+++ b/internal/provider/testutils.go
@@ -18,10 +18,12 @@ func testCheckResourceListAttr(name, key string, values []string) resource.TestC
 
 // The first character must be alphabet for algolia resources
 func randStringStartWithAlpha(length int) string {
+	const uuidLen = 21 // firstChar + xid(20 chars)
 	uuid := acctest.RandStringFromCharSet(1, acctest.CharSetAlpha) + xid.New().String()
-	if length < len(uuid) {
+
+	if length < uuidLen {
 		return uuid[:length]
 	}
 
-	return uuid + acctest.RandStringFromCharSet(length-len(uuid), acctest.CharSetAlphaNum)
+	return uuid + acctest.RandStringFromCharSet(length-uuidLen, acctest.CharSetAlphaNum)
 }


### PR DESCRIPTION
Since Algolia's api key is associated with `APP_ID`, we can't create resources for multiple apps with the same api key.

Reverts k-yomo/terraform-provider-algolia#16