### PR TITLE
Fix `highlight_and_snippet_config` is not imported

### DIFF
--- a/internal/provider/resource_index.go
+++ b/internal/provider/resource_index.go
@@ -157,6 +157,7 @@ func resourceIndex() *schema.Resource {
 							Elem:        &schema.Schema{Type: schema.TypeString},
 							Set:         schema.HashString,
 							Optional:    true,
+							Computed:    true,
 							Description: "List of attributes to snippet, with an optional maximum number of words to snippet.",
 						},
 						"highlight_pre_tag": {
@@ -174,7 +175,6 @@ func resourceIndex() *schema.Resource {
 						"snippet_ellipsis_text": {
 							Type:        schema.TypeString,
 							Optional:    true,
-							Default:     "…",
 							Description: "String used as an ellipsis indicator when a snippet is truncated.",
 						},
 						"restrict_highlight_and_snippet_arrays": {

--- a/internal/provider/resource_index_test.go
+++ b/internal/provider/resource_index_test.go
@@ -26,6 +26,12 @@ func TestAccResourceIndex(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "attributes_config.0.attributes_to_retrieve.0", "*"),
 					testCheckResourceListAttr(resourceName, "ranking_config.0.ranking", []string{"typo", "geo", "words", "filters", "proximity", "attribute", "exact", "custom"}),
 					resource.TestCheckNoResourceAttr(resourceName, "ranking_config.0.replicas.0"),
+					testCheckResourceListAttr(resourceName, "highlight_and_snippet_config.0.attributes_to_highlight", []string{}),
+					testCheckResourceListAttr(resourceName, "highlight_and_snippet_config.0.attributes_to_snippet", []string{}),
+					resource.TestCheckResourceAttr(resourceName, "highlight_and_snippet_config.0.highlight_pre_tag", "<em>"),
+					resource.TestCheckResourceAttr(resourceName, "highlight_and_snippet_config.0.highlight_post_tag", "</em>"),
+					resource.TestCheckResourceAttr(resourceName, "highlight_and_snippet_config.0.snippet_ellipsis_text", ""),
+					resource.TestCheckResourceAttr(resourceName, "highlight_and_snippet_config.0.restrict_highlight_and_snippet_arrays", "false"),
 				),
 			},
 			{
@@ -40,6 +46,12 @@ func TestAccResourceIndex(t *testing.T) {
 					resource.TestCheckNoResourceAttr(resourceName, "ranking_config.0.replicas.0"),
 					resource.TestCheckResourceAttr(resourceName, "faceting_config.0.max_values_per_facet", "50"),
 					resource.TestCheckResourceAttr(resourceName, "faceting_config.0.sort_facet_values_by", "alpha"),
+					testCheckResourceListAttr(resourceName, "highlight_and_snippet_config.0.attributes_to_highlight", []string{"title"}),
+					testCheckResourceListAttr(resourceName, "highlight_and_snippet_config.0.attributes_to_snippet", []string{"description:100"}),
+					resource.TestCheckResourceAttr(resourceName, "highlight_and_snippet_config.0.highlight_pre_tag", "<b>"),
+					resource.TestCheckResourceAttr(resourceName, "highlight_and_snippet_config.0.highlight_post_tag", "</b>"),
+					resource.TestCheckResourceAttr(resourceName, "highlight_and_snippet_config.0.snippet_ellipsis_text", "..."),
+					resource.TestCheckResourceAttr(resourceName, "highlight_and_snippet_config.0.restrict_highlight_and_snippet_arrays", "true"),
 				),
 			},
 			{
@@ -65,6 +77,7 @@ func testAccResourceIndexUpdate(name string) string {
 	return fmt.Sprintf(`
 resource "algolia_index" "%s" {
   name = "%s"
+
   attributes_config {
     searchable_attributes = [
       "title",
@@ -85,15 +98,26 @@ resource "algolia_index" "%s" {
       "body"
     ]
   }
+
   ranking_config {
     ranking = [
       "words",
       "proximity"
     ]
   }
+
   faceting_config {
     max_values_per_facet = 50
     sort_facet_values_by = "alpha"
+  }
+
+  highlight_and_snippet_config {
+    attributes_to_highlight = ["title"]
+    attributes_to_snippet = ["description:100"]
+    highlight_pre_tag = "<b>"
+    highlight_post_tag = "</b>"
+    snippet_ellipsis_text = "..."
+    restrict_highlight_and_snippet_arrays = true
   }
 
   languages_config {


### PR DESCRIPTION
Fix #40 

`highlight_and_snippet_config` was actually not set at all.