### PR TITLE
Emit request / response logs  if TF_LOG is DEBUG or higher

### DIFF
--- a/internal/algoliautil/http.go
+++ b/internal/algoliautil/http.go
@@ -1,0 +1,21 @@
+package algoliautil
+
+import (
+	"net/http"
+
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/transport"
+)
+
+type DebugRequester struct {
+	Client *http.Client
+}
+
+func NewDebugRequester() *DebugRequester {
+	return &DebugRequester{
+		Client: transport.DefaultHTTPClient(),
+	}
+}
+
+func (d *DebugRequester) Request(req *http.Request) (*http.Response, error) {
+	return d.Client.Do(req)
+}

--- a/internal/algoliautil/http.go
+++ b/internal/algoliautil/http.go
@@ -1,7 +1,12 @@
 package algoliautil
 
 import (
+	"bytes"
+	"encoding/json"
+	"log"
 	"net/http"
+	"net/http/httputil"
+	"strings"
 
 	"github.com/algolia/algoliasearch-client-go/v3/algolia/transport"
 )
@@ -11,11 +16,85 @@ type DebugRequester struct {
 }
 
 func NewDebugRequester() *DebugRequester {
+	httpClient := transport.DefaultHTTPClient()
+	httpClient.Transport = newDebugTransport(httpClient.Transport)
 	return &DebugRequester{
-		Client: transport.DefaultHTTPClient(),
+		Client: httpClient,
 	}
 }
 
 func (d *DebugRequester) Request(req *http.Request) (*http.Response, error) {
 	return d.Client.Do(req)
 }
+
+// Code from below is basically copied from the following logging helper
+//(need to copy to mask secrets)
+// https://github.com/hashicorp/terraform-plugin-sdk/blob/45133e6e2aebbe0aca05427cbcd360f968979e98/helper/logging/transport.go#L12
+type debugTransport struct {
+	name      string
+	transport http.RoundTripper
+}
+
+func (t *debugTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	reqData, err := httputil.DumpRequestOut(req, true)
+	if err == nil {
+		log.Printf("[DEBUG] "+logReqMsg, t.name, prettyPrintJsonLines(reqData))
+	} else {
+		log.Printf("[ERROR] %s API Request error: %#v", t.name, err)
+	}
+
+	resp, err := t.transport.RoundTrip(req)
+	if err != nil {
+		return resp, err
+	}
+
+	respData, err := httputil.DumpResponse(resp, true)
+	if err == nil {
+		log.Printf("[DEBUG] "+logRespMsg, t.name, prettyPrintJsonLines(respData))
+	} else {
+		log.Printf("[ERROR] %s API Response error: %#v", t.name, err)
+	}
+
+	return resp, nil
+}
+
+func newDebugTransport(t http.RoundTripper) *debugTransport {
+	return &debugTransport{name: "Algolia", transport: t}
+}
+
+// prettyPrintJsonLines iterates through a []byte line-by-line,
+// transforming any lines that are complete json into pretty-printed json.
+func prettyPrintJsonLines(b []byte) string {
+	parts := strings.Split(string(b), "\n")
+	for i, p := range parts {
+		if b := []byte(p); json.Valid(b) {
+			var out bytes.Buffer
+			if err := json.Indent(&out, b, "", " "); err != nil {
+				continue
+			}
+			parts[i] = out.String()
+		}
+		// Mask following header values
+		// X-Algolia-Api-Key
+		// X-Algolia-Application-Id
+		if strings.Contains(strings.ToLower(p), "x-algolia") {
+			kv := strings.Split(p, ": ")
+			if len(kv) != 2 {
+				continue
+			}
+			kv[1] = strings.Repeat("*", len(kv[1]))
+			parts[i] = strings.Join(kv, ": ")
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+const logReqMsg = `%s API Request Details:
+---[ REQUEST ]---------------------------------------
+%s
+-----------------------------------------------------`
+
+const logRespMsg = `%s API Response Details:
+---[ RESPONSE ]--------------------------------------
+%s
+-----------------------------------------------------`

--- a/internal/algoliautil/http_test.go
+++ b/internal/algoliautil/http_test.go
@@ -1,0 +1,20 @@
+package algoliautil
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/transport"
+)
+
+func TestNewDebugRequester(t *testing.T) {
+	t.Parallel()
+
+	got := NewDebugRequester()
+	want := &DebugRequester{
+		Client: transport.DefaultHTTPClient(),
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("NewDebugRequester() = %v, want %v", got, want)
+	}
+}

--- a/internal/algoliautil/http_test.go
+++ b/internal/algoliautil/http_test.go
@@ -3,18 +3,14 @@ package algoliautil
 import (
 	"reflect"
 	"testing"
-
-	"github.com/algolia/algoliasearch-client-go/v3/algolia/transport"
 )
 
 func TestNewDebugRequester(t *testing.T) {
 	t.Parallel()
 
 	got := NewDebugRequester()
-	want := &DebugRequester{
-		Client: transport.DefaultHTTPClient(),
-	}
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("NewDebugRequester() = %v, want %v", got, want)
+	// assert not nil
+	if reflect.DeepEqual(got, nil) {
+		t.Errorf("NewDebugRequester() = %v, want %v", got, nil)
 	}
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -81,9 +81,7 @@ func configure(version string, p *schema.Provider) func(context.Context, *schema
 func newAPIClient(appID, apiKey, userAgent string) *apiClient {
 	var algoliaRequester transport.Requester
 	if logging.IsDebugOrHigher() {
-		debugRequester := algoliautil.NewDebugRequester()
-		debugRequester.Client.Transport = logging.NewTransport("Algolia", debugRequester.Client.Transport)
-		algoliaRequester = debugRequester
+		algoliaRequester = algoliautil.NewDebugRequester()
 	}
 
 	searchConfig := search.Configuration{

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -6,8 +6,11 @@ import (
 	"github.com/algolia/algoliasearch-client-go/v3/algolia/region"
 	"github.com/algolia/algoliasearch-client-go/v3/algolia/search"
 	"github.com/algolia/algoliasearch-client-go/v3/algolia/suggestions"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/transport"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-algolia/internal/algoliautil"
 )
 
 // nolint: gochecknoinits
@@ -53,6 +56,7 @@ type apiClient struct {
 	userAgent string
 	appID     string
 	apiKey    string
+	requester transport.Requester
 
 	searchClient *search.Client
 }
@@ -63,6 +67,7 @@ func (a *apiClient) newSuggestionsClient(region region.Region) *suggestions.Clie
 		APIKey:         a.apiKey,
 		Region:         region,
 		ExtraUserAgent: a.userAgent,
+		Requester:      a.requester,
 	})
 }
 
@@ -74,10 +79,18 @@ func configure(version string, p *schema.Provider) func(context.Context, *schema
 }
 
 func newAPIClient(appID, apiKey, userAgent string) *apiClient {
+	var algoliaRequester transport.Requester
+	if logging.IsDebugOrHigher() {
+		debugRequester := algoliautil.NewDebugRequester()
+		debugRequester.Client.Transport = logging.NewTransport("Algolia", debugRequester.Client.Transport)
+		algoliaRequester = debugRequester
+	}
+
 	searchConfig := search.Configuration{
 		AppID:          appID,
 		APIKey:         apiKey,
 		ExtraUserAgent: userAgent,
+		Requester:      algoliaRequester,
 	}
 	searchClient := search.NewClientWithConfig(searchConfig)
 
@@ -85,6 +98,7 @@ func newAPIClient(appID, apiKey, userAgent string) *apiClient {
 		appID:        appID,
 		apiKey:       apiKey,
 		userAgent:    userAgent,
+		requester:    algoliaRequester,
 		searchClient: searchClient,
 	}
 }


### PR DESCRIPTION
This PR make it possible to emit request/response logs when TF_LOG is `DEBUG` or higher as following.


```
---[ REQUEST ]---------------------------------------
PUT /1/indexes/debug_test/settings HTTP/1.1
Host: DXOXWY4Y18.algolia.net
User-Agent: Terraform/0.15.0 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-algolia/dev;Algolia for Go (3.23.0);Go (go1.17)
Transfer-Encoding: chunked
Connection: Keep-Alive
Content-Type: application/json; charset=utf-8
X-Algolia-Api-Key: **********************************
X-Algolia-Application-Id: ***************
Accept-Encoding: gzip

15
{
 "enableRules": true
}

0


-----------------------------------------------------: timestamp=2022-02-26T00:19:52.291+0900
2022-02-26T00:19:52.304+0900 [INFO]  provider.terraform-provider-algolia: 2022/02/26 00:19:52 [DEBUG] Algolia API Response Details:
---[ RESPONSE ]--------------------------------------
HTTP/1.1 200 OK
Transfer-Encoding: chunked
Accept-Encoding: deflate, gzip
Access-Control-Allow-Origin: *
Cache-Control: no-store
Connection: keep-alive
Content-Disposition: inline; filename=a.txt
Content-Type: application/json; charset=UTF-8
Date: Fri, 25 Feb 2022 15:19:52 GMT
Server: nginx
Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
Timing-Allow-Origin: *
X-Content-Type-Options: nosniff

2f6
{
 "minWordSizefor1Typo": 4,
 "minWordSizefor2Typos": 8,
 "hitsPerPage": 20,
 "maxValuesPerFacet": 100,
 "version": 2,
 "attributesToIndex": null,
 "numericAttributesToIndex": null,
 "attributesToRetrieve": null,
 "unretrievableAttributes": null,
 "optionalWords": null,
 "attributesForFaceting": null,
 "attributesToSnippet": null,
 "attributesToHighlight": null,
 "paginationLimitedTo": 1000,
 "attributeForDistinct": null,
 "exactOnSingleWordQuery": "attribute",
 "ranking": [
  "typo",
  "geo",
  "words",
  "filters",
  "proximity",
  "attribute",
  "exact",
  "custom"
 ],
 "customRanking": null,
 "separatorsToIndex": "",
 "removeWordsIfNoResults": "none",
 "queryType": "prefixLast",
 "highlightPreTag": "<em>",
 "highlightPostTag": "</em>",
 "snippetEllipsisText": "",
 "alternativesAsExact": [
  "ignorePlurals",
  "singleWordSynonym"
 ],
 "enableRules": true
}
0
```