### PR TITLE
Revert "Add 'virtual' computed param not to try to update unsupported params for virtual replica index"

### DIFF
--- a/docs/data-sources/index.md
+++ b/docs/data-sources/index.md
@@ -43,7 +43,6 @@ data "algolia_index" "example" {
 - `query_strategy_config` (List of Object) The configuration for query strategy in index setting. (see [below for nested schema](#nestedatt--query_strategy_config))
 - `ranking_config` (List of Object) The configuration for ranking. (see [below for nested schema](#nestedatt--ranking_config))
 - `typos_config` (List of Object) The configuration for typos in index setting. (see [below for nested schema](#nestedatt--typos_config))
-- `virtual` (Boolean) Whether the index is virtual index.
 
 <a id="nestedatt--advanced_config"></a>
 ### Nested Schema for `advanced_config`

--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -79,10 +79,6 @@ resource "algolia_index" "example" {
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `typos_config` (Block List, Max: 1) The configuration for typos in index setting. (see [below for nested schema](#nestedblock--typos_config))
 
-### Read-Only
-
-- `virtual` (Boolean) Whether the index is virtual index. If true, applying the params listed in the [doc](https://www.algolia.com/doc/guides/managing-results/refine-results/sorting/in-depth/replicas/#unsupported-parameters) will be ignored.
-
 <a id="nestedblock--advanced_config"></a>
 ### Nested Schema for `advanced_config`
 

--- a/internal/provider/data_source_index.go
+++ b/internal/provider/data_source_index.go
@@ -19,11 +19,6 @@ func dataSourceIndex() *schema.Resource {
 				ForceNew:    true,
 				Description: "Name of the index.",
 			},
-			"virtual": {
-				Type:        schema.TypeBool,
-				Computed:    true,
-				Description: "Whether the index is virtual index.",
-			},
 			"attributes_config": {
 				Type:        schema.TypeList,
 				Computed:    true,

--- a/internal/provider/data_source_index_test.go
+++ b/internal/provider/data_source_index_test.go
@@ -19,7 +19,6 @@ func TestAccDataSourceIndex(t *testing.T) {
 				Config: testAccDatasourceIndex(indexName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "name", indexName),
-					resource.TestCheckResourceAttr(dataSourceName, "virtual", "false"),
 					testCheckResourceListAttr(dataSourceName, "attributes_config.0.searchable_attributes", []string{"title", "category,tag", "unordered(description)"}),
 					testCheckResourceListAttr(dataSourceName, "attributes_config.0.attributes_for_faceting", []string{"category"}),
 					testCheckResourceListAttr(dataSourceName, "attributes_config.0.unretrievable_attributes", []string{"author_email"}),

--- a/internal/provider/resource_index_test.go
+++ b/internal/provider/resource_index_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 // TODO: Cover all params
-// TODO: Add a test for virtual index (virtual index can't be created on current Free plan)
 func TestAccResourceIndex(t *testing.T) {
 	indexName := randStringStartWithAlpha(100)
 	resourceName := fmt.Sprintf("algolia_index.%s", indexName)
@@ -23,7 +22,6 @@ func TestAccResourceIndex(t *testing.T) {
 				Config: testAccResourceIndex(indexName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", indexName),
-					resource.TestCheckResourceAttr(resourceName, "virtual", "false"),
 					resource.TestCheckNoResourceAttr(resourceName, "attributes_config.0.searchable_attributes.0"),
 					resource.TestCheckNoResourceAttr(resourceName, "attributes_config.0.attributes_for_faceting.0"),
 					resource.TestCheckNoResourceAttr(resourceName, "attributes_config.0.unretrievable_attributes.0"),
@@ -49,7 +47,6 @@ func TestAccResourceIndex(t *testing.T) {
 				Config: testAccResourceIndexUpdate(indexName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", indexName),
-					resource.TestCheckResourceAttr(resourceName, "virtual", "false"),
 					testCheckResourceListAttr(resourceName, "attributes_config.0.searchable_attributes", []string{"title", "category,tag", "unordered(description)"}),
 					testCheckResourceListAttr(resourceName, "attributes_config.0.attributes_for_faceting", []string{"category"}),
 					testCheckResourceListAttr(resourceName, "attributes_config.0.unretrievable_attributes", []string{"author_email"}),


### PR DESCRIPTION
This reverts commit f896e6554ecb28596bd8517db577209c05c3e0d1.
The detection is incorrect, reverting this will mean unnecessary
setSettings are performed to virtual replicas, but it seems better than
missing setSettings to non-virtual replicas.

Fixes #79 