### PR TITLE
Document how to setup virtual replicas

### DIFF
--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -51,6 +51,42 @@ resource "algolia_index" "example" {
   languages_config {
     remove_stop_words_for = ["en"]
   }
+
+  replicas = ["virtual(example_replica)"]
+}
+
+resource "algolia_index" "example_virtual_replica" {
+  name    = "example_replica"
+  virtual = true
+
+  attributes_config {
+    unretrievable_attributes = [
+      "author_email"
+    ]
+    attributes_to_retrieve = [
+      "title",
+      "category",
+      "tag",
+      "description",
+      "body"
+    ]
+  }
+
+  ranking_config {
+    ranking = [
+      "proximity"
+      "words",
+    ]
+  }
+
+  faceting_config {
+    max_values_per_facet = 50
+    sort_facet_values_by = "alpha"
+  }
+
+  languages_config {
+    remove_stop_words_for = ["en"]
+  }
 }
 ```
 
@@ -59,7 +95,7 @@ resource "algolia_index" "example" {
 
 ### Required
 
-- `name` (String) Name of the index.
+- `name` (String) Name of the index. If the index is a virtual replica, its name should NOT be surrounded with `virtual()`.
 
 ### Optional
 
@@ -206,7 +242,7 @@ Optional:
 
 - `custom_ranking` (List of String) List of attributes for custom ranking criterion.
 - `ranking` (List of String) List of ranking criteria.
-- `replicas` (Set of String) List of replica names.
+- `replicas` (Set of String) List of replica names. Names of virtual replicas should be surrounded with `virtual()`.
 
 
 <a id="nestedblock--timeouts"></a>

--- a/examples/resources/algolia_index/resource.tf
+++ b/examples/resources/algolia_index/resource.tf
@@ -36,4 +36,40 @@ resource "algolia_index" "example" {
   languages_config {
     remove_stop_words_for = ["en"]
   }
+
+  replicas = ["virtual(example_replica)"]
+}
+
+resource "algolia_index" "example_virtual_replica" {
+  name    = "example_replica"
+  virtual = true
+
+  attributes_config {
+    unretrievable_attributes = [
+      "author_email"
+    ]
+    attributes_to_retrieve = [
+      "title",
+      "category",
+      "tag",
+      "description",
+      "body"
+    ]
+  }
+
+  ranking_config {
+    ranking = [
+      "proximity"
+      "words",
+    ]
+  }
+
+  faceting_config {
+    max_values_per_facet = 50
+    sort_facet_values_by = "alpha"
+  }
+
+  languages_config {
+    remove_stop_words_for = ["en"]
+  }
 }

--- a/internal/provider/resource_index.go
+++ b/internal/provider/resource_index.go
@@ -33,7 +33,7 @@ func resourceIndex() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				Description: "Name of the index.",
+				Description: "Name of the index. If the index is a virtual replica, its name should NOT be surrounded with `virtual()`.",
 			},
 			"virtual": {
 				Type:        schema.TypeBool,
@@ -119,7 +119,7 @@ func resourceIndex() *schema.Resource {
 							Elem:        &schema.Schema{Type: schema.TypeString},
 							Set:         schema.HashString,
 							Optional:    true,
-							Description: "List of replica names.",
+							Description: "List of replica names. Names of virtual replicas should be surrounded with `virtual()`.",
 						},
 					},
 				},


### PR DESCRIPTION
It's far from being obvious: the name should be surrounded with
`virtual()` in one place but not the other, and for now, you also have to
set the virtual option to `true` manually.