### PR TITLE
Remove RequiredWith constraint for distinct field

### DIFF
--- a/internal/provider/resource_index.go
+++ b/internal/provider/resource_index.go
@@ -515,10 +515,12 @@ List of supported languages are listed on http://nhttps//www.algolia.com/doc/api
 							Description:  "Name of the de-duplication attribute to be used with the `distinct` feature.",
 						},
 						"distinct": {
-							Type:         schema.TypeInt,
-							Optional:     true,
-							Default:      0,
-							RequiredWith: []string{"advanced_config.0.attribute_for_distinct"},
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  0,
+							// `distinct` requires `attribute_for_distinct` but disable the constraint here for virtual index.
+							// since `attribute_for_distinct` can't be set in virtual index.
+							// RequiredWith: []string{"advanced_config.0.attribute_for_distinct"},
 							Description: `Whether to enable de-duplication or grouping of results.
 - When set to ` + "`0`" + `, you disable de-duplication and grouping.
 - When set to ` + "`1`" + `, you enable **de-duplication**, in which only the most relevant result is returned for all records that have the same value in the distinct attribute. This is similar to the SQL ` + "`distinct`" + ` keyword.

--- a/internal/provider/resource_index_test.go
+++ b/internal/provider/resource_index_test.go
@@ -107,10 +107,14 @@ func TestAccResourceVirtualIndex(t *testing.T) {
 					testCheckResourceListAttr(indexResourceName, "attributes_config.0.attributes_for_faceting", []string{"category_id"}),
 					testCheckResourceListAttr(indexResourceName, "ranking_config.0.ranking", []string{"typo", "geo"}),
 					testCheckResourceListAttr(indexResourceName, "ranking_config.0.replicas", []string{fmt.Sprintf("virtual(%s)", virtualIndexName)}),
+					resource.TestCheckResourceAttr(indexResourceName, "advanced_config.0.distinct", "2"),
+					resource.TestCheckResourceAttr(indexResourceName, "advanced_config.0.attribute_for_distinct", "url"),
 					// virtual index
 					resource.TestCheckResourceAttr(virtualIndexResourceName, "name", virtualIndexName),
 					resource.TestCheckResourceAttr(virtualIndexResourceName, "virtual", "true"),
 					testCheckResourceListAttr(virtualIndexResourceName, "ranking_config.0.custom_ranking", []string{"desc(likes)"}),
+					testCheckResourceListAttr(virtualIndexResourceName, "advanced_config.0.response_fields", []string{"*"}),
+					resource.TestCheckResourceAttr(virtualIndexResourceName, "advanced_config.0.distinct", "1"),
 					resource.TestCheckResourceAttr(virtualIndexResourceName, "deletion_protection", "false"),
 				),
 			},
@@ -123,6 +127,7 @@ func TestAccResourceVirtualIndex(t *testing.T) {
 					"virtual",
 					"attributes_config",
 					"ranking_config",
+					"advanced_config",
 					"performance_config",
 					"deletion_protection",
 				},
@@ -232,6 +237,12 @@ resource "algolia_index" "` + name + `" {
     replicas = ["virtual(` + virtualIndexName + `)"]
   }
 
+  advanced_config {
+    response_fields = ["*"]
+    distinct = 2
+    attribute_for_distinct = "url"
+  }
+
   deletion_protection = false
 }
 
@@ -241,6 +252,11 @@ resource "algolia_index" "` + virtualIndexName + `" {
 
   ranking_config {
     custom_ranking = ["desc(likes)"]
+  }
+
+  advanced_config {
+    response_fields = ["*"]
+    distinct = 1
   }
 
   deletion_protection = false


### PR DESCRIPTION
This PR removes `RequiredWith` constraint for `distinct` field, since `attribute_for_distinct` can't be set in virtual index.

Fixes #94 