### PR TITLE
Introduce KV mutex

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -14,7 +14,7 @@ generate:
 # Run acceptance tests
 .PHONY: testacc
 testacc:
-	TF_ACC=1 go test ./... -v $(TESTARGS) -coverprofile=coverage.out -timeout 120m
+	TF_ACC=1 go test ./... -v $(TESTARGS) -race -coverprofile=coverage.out -timeout 120m
 
 # Run acceptance tests and show coverages
 .PHONY: testacc-cover

--- a/internal/mutex/kv.go
+++ b/internal/mutex/kv.go
@@ -1,0 +1,49 @@
+package mutex
+
+import (
+	"log"
+	"sync"
+)
+
+// KV is a simple key/value store for arbitrary mutexes. It can be used to
+// serialize changes across arbitrary collaborators that share knowledge of the
+// keys they must serialize on.
+//
+type KV struct {
+	lock  sync.Mutex
+	store map[string]*sync.Mutex
+}
+
+// NewKV returns a properly initialized KV
+func NewKV() *KV {
+	return &KV{
+		store: make(map[string]*sync.Mutex),
+	}
+}
+
+// Lock the mutex for the given key. Caller is responsible for calling Unlock
+// for the same key
+func (m *KV) Lock(key string) {
+	log.Printf("[DEBUG] Locking %q", key)
+	m.get(key).Lock()
+	log.Printf("[DEBUG] Locked %q", key)
+}
+
+// Unlock the mutex for the given key. Caller must have called Lock for the same key first
+func (m *KV) Unlock(key string) {
+	log.Printf("[DEBUG] Unlocking %q", key)
+	m.get(key).Unlock()
+	log.Printf("[DEBUG] Unlocked %q", key)
+}
+
+// Returns a mutex for the given key, no guarantee of its lock status
+func (m *KV) get(key string) *sync.Mutex {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	mutex, ok := m.store[key]
+	if !ok {
+		mutex = &sync.Mutex{}
+		m.store[key] = mutex
+	}
+	return mutex
+}

--- a/internal/mutex/kv_test.go
+++ b/internal/mutex/kv_test.go
@@ -1,0 +1,38 @@
+package mutex
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestKV(t *testing.T) {
+	t.Parallel()
+
+	mutexKV := NewKV()
+	start := time.Now()
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		mutexKV.Lock("test")
+		time.Sleep(100 * time.Millisecond)
+		mutexKV.Unlock("test")
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		mutexKV.Lock("test")
+		time.Sleep(100 * time.Millisecond)
+		mutexKV.Unlock("test")
+	}()
+	wg.Wait()
+
+	if elapsed := time.Since(start); elapsed < 200*time.Millisecond {
+		t.Errorf("TestKV() elapsed time = %v, want %v", elapsed, 200*time.Millisecond)
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-
 	"github.com/algolia/algoliasearch-client-go/v3/algolia/region"
 	"github.com/algolia/algoliasearch-client-go/v3/algolia/search"
 	"github.com/algolia/algoliasearch-client-go/v3/algolia/suggestions"
@@ -11,7 +10,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-algolia/internal/algoliautil"
+	"github.com/hashicorp/terraform-provider-algolia/internal/mutex"
 )
+
+// Global Key/Value Mutex
+var mutexKV = mutex.NewKV()
 
 // nolint: gochecknoinits
 func init() {


### PR DESCRIPTION
Standard replica and virtual replica will modify the primary index config and it can conflict and produce unexpected result.
This PR introduce mutex to force those modification will be executed in series to avoid it.

Related PR: https://github.com/k-yomo/terraform-provider-algolia/pull/102