### PR TITLE
Fix to unlock when returning error

### DIFF
--- a/internal/provider/resource_virtual_index.go
+++ b/internal/provider/resource_virtual_index.go
@@ -574,6 +574,7 @@ func resourceVirtualIndexCreate(ctx context.Context, d *schema.ResourceData, m i
 	mutexKV.Lock(ctx, algoliaIndexMutexKey(apiClient.appID, primaryIndexName))
 	primaryIndexSettings, err := primaryIndex.GetSettings(ctx)
 	if err != nil {
+		mutexKV.Unlock(ctx, algoliaIndexMutexKey(apiClient.appID, primaryIndexName))
 		return diag.FromErr(err)
 	}
 	replicas := primaryIndexSettings.Replicas.Get()
@@ -584,9 +585,11 @@ func resourceVirtualIndexCreate(ctx context.Context, d *schema.ResourceData, m i
 			Replicas: opt.Replicas(newReplicas...),
 		})
 		if err != nil {
+			mutexKV.Unlock(ctx, algoliaIndexMutexKey(apiClient.appID, primaryIndexName))
 			return diag.FromErr(err)
 		}
 		if err := res.Wait(); err != nil {
+			mutexKV.Unlock(ctx, algoliaIndexMutexKey(apiClient.appID, primaryIndexName))
 			return diag.FromErr(err)
 		}
 	}


### PR DESCRIPTION
Missing unlocking when we do an early return for error.
This PR probably fixes the below issue.
https://github.com/k-yomo/terraform-provider-algolia/issues/127