### PR TITLE
Fix to set empty array instead of null for array field

### DIFF
--- a/internal/provider/datautils.go
+++ b/internal/provider/datautils.go
@@ -14,7 +14,8 @@ func setValues(d *schema.ResourceData, values map[string]interface{}) error {
 }
 
 func castStringList(list interface{}) []string {
-	var strs []string
+	// we are initializing non nil array to be marshaled to [] in JSON
+	strs := []string{}
 	for _, v := range list.([]interface{}) {
 		strs = append(strs, v.(string))
 	}
@@ -22,7 +23,8 @@ func castStringList(list interface{}) []string {
 }
 
 func castStringSet(set interface{}) []string {
-	var strs []string
+	// we are initializing non nil array to be marshaled to [] in JSON
+	strs := []string{}
 	for _, v := range set.(*schema.Set).List() {
 		strs = append(strs, v.(string))
 	}


### PR DESCRIPTION
Resolves #136
The below initialization will initialize nil and marshaled to `null` in JSON.
```go
var test []string
```

For some fields, `null` and `[]` have different meaning, so this PR fixes to set empty array to be marshaled to `[]` in JSON.