### PR TITLE
Unskip replica index test

### DIFF
--- a/internal/provider/resource_index_test.go
+++ b/internal/provider/resource_index_test.go
@@ -85,11 +85,6 @@ func TestAccResourceIndex(t *testing.T) {
 }
 
 func TestAccResourceIndexWithReplica(t *testing.T) {
-	// NOTE: Deleting replica fails due to the same reason as the below issue.
-	// https://github.com/algolia/algoliasearch-client-javascript/issues/1377
-	// TODO: Remove t.Skip() once the issue is resolved.
-	t.Skip()
-
 	primaryIndexName := randResourceID(80)
 	replicaIndexName := fmt.Sprintf("%s_replica", primaryIndexName)
 	primaryIndexResourceName := fmt.Sprintf("algolia_index.%s", primaryIndexName)


### PR DESCRIPTION
Resolves #103 

It seems now replica index can be deleted via API.