### PR TITLE
Add json_params to algolia_rule.consequence

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.48
+          version: v1.57
 
       - name: Docs check
         run: make docs-check

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -5,7 +5,7 @@ DEV_VERSION=999.999.999
 # Build provider and place it plugins directory to be able to sideload the built provider.
 .PHONY: install
 install:
-	go build -o ~/.terraform.d/plugins/registry.terraform.io/k-yomo/algolia/${DEV_VERSION}/darwin_amd64/terraform-provider-algolia
+	go build -o ~/.terraform.d/plugins/registry.terraform.io/k-yomo/algolia/${DEV_VERSION}/darwin_arm64/terraform-provider-algolia
 
 .PHONY: generate
 generate:

--- a/README.md
+++ b/README.md
@@ -91,12 +91,12 @@ resource "algolia_rule" "example" {
   }
 
   consequence {
-    params {
-      automatic_facet_filters {
+    params_json = jsondecode({
+      automaticFacetFilters = {
         facet = "category"
         disjunctive = true
       }
-    }
+    })
   }
 }
 

--- a/docs/resources/rule.md
+++ b/docs/resources/rule.md
@@ -64,7 +64,8 @@ At least one of the following object must be used:
 Optional:
 
 - `hide` (Set of String) List of object IDs to hide from hits.
-- `params` (Block List, Max: 1) Additional search parameters. Any valid search parameter is allowed. Specific treatment is applied to these fields: `query`, `automaticFacetFilters`, `automaticOptionalFacetFilters`. (see [below for nested schema](#nestedblock--consequence--params))
+- `params` (Block List, Max: 1, Deprecated) **Deprecated:** Use `params_json` instead. Additional search parameters. Any valid search parameter is allowed. Specific treatment is applied to these fields: `query`, `automaticFacetFilters`, `automaticOptionalFacetFilters`. (see [below for nested schema](#nestedblock--consequence--params))
+- `params_json` (String) Additional search parameters in JSON format. Any valid search parameter is allowed. Specific treatment is applied to these fields: `query`, `automaticFacetFilters`, `automaticOptionalFacetFilters`.
 - `promote` (Block List) Objects to promote as hits. (see [below for nested schema](#nestedblock--consequence--promote))
 - `user_data` (String) Custom JSON formatted string that will be appended to the userData array in the response. This object is not interpreted by the API. It is limited to 1kB of minified JSON.
 

--- a/internal/provider/datautils.go
+++ b/internal/provider/datautils.go
@@ -1,6 +1,9 @@
 package provider
 
 import (
+	"encoding/json"
+	"reflect"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -45,4 +48,25 @@ func castInterfaceMap(m interface{}) map[string]interface{} {
 		interfaceMap[k] = v
 	}
 	return interfaceMap
+}
+
+func diffJsonSuppress(k, old, new string, d *schema.ResourceData) bool {
+	result, _ := jsonBytesEqual([]byte(old), []byte(new))
+	return result
+}
+
+// jsonBytesEqual compares the JSON in two byte slices
+func jsonBytesEqual(a, b []byte) (bool, error) {
+	var j, j2 interface{}
+	if err := json.Unmarshal(a, &j); err != nil {
+		return false, err
+	}
+	if err := json.Unmarshal(b, &j2); err != nil {
+		return false, err
+	}
+	return mapsEqual(j, j2), nil
+}
+
+func mapsEqual(m1, m2 interface{}) bool {
+	return reflect.DeepEqual(m2, m1)
 }

--- a/internal/provider/resource_rule_test.go
+++ b/internal/provider/resource_rule_test.go
@@ -26,8 +26,7 @@ func TestAccResourceRule(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "object_id", objectID),
 					resource.TestCheckResourceAttr(resourceName, "conditions.0.pattern", "{facet:category}"),
 					resource.TestCheckResourceAttr(resourceName, "conditions.0.anchoring", "contains"),
-					resource.TestCheckResourceAttr(resourceName, "consequence.0.params.0.automatic_facet_filters.0.facet", "category"),
-					resource.TestCheckResourceAttr(resourceName, "consequence.0.params.0.automatic_facet_filters.0.disjunctive", "true"),
+					resource.TestCheckResourceAttr(resourceName, "consequence.0.params_json", `{"automaticFacetFilters":[{"facet":"category","disjunctive":true,"score":0}]}`),
 					// testCheckResourceListAttr(resourceName, "consequence.0.promote.0.object_ids", []string{"promote-12345"}),
 					// resource.TestCheckResourceAttr(resourceName, "consequence.0.promote.0.position", "0"),
 					// testCheckResourceListAttr(resourceName, "consequence.0.hide", []string{"hide-12345"}),
@@ -40,8 +39,7 @@ func TestAccResourceRule(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "object_id", objectID),
 					resource.TestCheckResourceAttr(resourceName, "conditions.0.pattern", "{facet:tag}"),
 					resource.TestCheckResourceAttr(resourceName, "conditions.0.anchoring", "is"),
-					resource.TestCheckResourceAttr(resourceName, "consequence.0.params.0.automatic_facet_filters.0.facet", "tag"),
-					resource.TestCheckResourceAttr(resourceName, "consequence.0.params.0.automatic_facet_filters.0.disjunctive", "true"),
+					resource.TestCheckResourceAttr(resourceName, "consequence.0.params_json", `{"query":{"edits":[{"type":"remove","delete":"tag"}]},"automaticFacetFilters":[{"facet":"tag","disjunctive":true,"score":0}]}`),
 					resource.TestCheckResourceAttr(resourceName, "validity.0.from", "2030-01-01T00:00:00Z"),
 					resource.TestCheckResourceAttr(resourceName, "validity.0.until", "2030-03-31T23:59:59Z"),
 				),
@@ -75,12 +73,13 @@ resource "algolia_rule" "` + objectID + `" {
   }
 
   consequence {
-    params {
-      automatic_facet_filters {
+    params_json = jsonencode({
+      automaticFacetFilters = [{
         facet       = "category"
         disjunctive = true
-      }
-    }
+        score 	    = 0
+      }]
+    })
     // specifying id cause 404 error
     //promote {
     //  object_ids  = ["promote-12345"]
@@ -105,16 +104,19 @@ resource "algolia_rule" "` + objectID + `" {
   }
 
   consequence {
-    params {
-      object_query {
-		type = "remove"
-        delete = "tag"
+    params_json = jsonencode({
+      query = {
+		edits = [{
+          type = "remove"
+          delete = "tag"
+		}]
       }
-      automatic_facet_filters {
+      automaticFacetFilters = [{
         facet       = "tag"
         disjunctive = true
-      }
-    }
+        score 	    = 0
+      }]
+    })
   }
 
   validity {

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,4 +1,4 @@
-// +build tools
+//go:build tools
 
 package tools
 


### PR DESCRIPTION
Resolve https://github.com/k-yomo/terraform-provider-algolia/issues/208

- Add `params_json` to  correctly handle `params`
- Deprecate `params` and recommend using `json_params` instead.