### PR TITLE
explicitly mark id as computed

### DIFF
--- a/docs/resources/query_suggestions.md
+++ b/docs/resources/query_suggestions.md
@@ -65,7 +65,7 @@ Optional:
 - `analytics_tags` (Set of String) A list of analytics tags to filter the popular searches per tag.
 - `external` (Set of String) A list of external indices to use to generate custom Query Suggestions.
 - `facets` (Block List) A list of facets to define as categories for the query suggestions. (see [below for nested schema](#nestedblock--source_indices--facets))
-- `generate` (List of List of String) List of facet attributes used to generate Query Suggestions. The resulting suggestions are every combination of the facets in the nested list 
+- `generate` (List of List of String) List of facet attributes used to generate Query Suggestions. The resulting suggestions are every combination of the facets in the nested list
 (e.g., (facetA and facetB) and facetC).
 ```
 [

--- a/docs/resources/rule.md
+++ b/docs/resources/rule.md
@@ -38,7 +38,7 @@ resource "algolia_rule" "example" {
 
 ### Required
 
-- `consequence` (Block List, Min: 1, Max: 1) Consequence of the Rule. 
+- `consequence` (Block List, Min: 1, Max: 1) Consequence of the Rule.
 At least one of the following object must be used:
 - params
 - promote

--- a/internal/provider/resource_api_key.go
+++ b/internal/provider/resource_api_key.go
@@ -26,6 +26,10 @@ func resourceAPIKey() *schema.Resource {
 		Description: "A configuration for an API key",
 		// https://www.algolia.com/doc/api-reference/api-methods/add-api-key/
 		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"key": {
 				Type:        schema.TypeString,
 				Computed:    true,

--- a/internal/provider/resource_index.go
+++ b/internal/provider/resource_index.go
@@ -30,6 +30,10 @@ func resourceIndex() *schema.Resource {
 		},
 		// https://www.algolia.com/doc/api-reference/settings-api-parameters/
 		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,

--- a/internal/provider/resource_query_suggestions.go
+++ b/internal/provider/resource_query_suggestions.go
@@ -27,6 +27,10 @@ func resourceQuerySuggestions() *schema.Resource {
 		Description: "A configuration that lies behind your Query Suggestions index.",
 		// https://www.algolia.com/doc/rest-api/query-suggestions/#create-a-configuration
 		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"index_name": {
 				Type:        schema.TypeString,
 				Required:    true,
@@ -103,7 +107,7 @@ func resourceQuerySuggestions() *schema.Resource {
 								Type: schema.TypeList,
 								Elem: &schema.Schema{Type: schema.TypeString},
 							},
-							Description: `List of facet attributes used to generate Query Suggestions. The resulting suggestions are every combination of the facets in the nested list 
+							Description: `List of facet attributes used to generate Query Suggestions. The resulting suggestions are every combination of the facets in the nested list
 (e.g., (facetA and facetB) and facetC).
 ` + "```" + `
 [

--- a/internal/provider/resource_rule.go
+++ b/internal/provider/resource_rule.go
@@ -31,6 +31,10 @@ func resourceRule() *schema.Resource {
 		Description: "A configuration for a Rule.  To get more information about rules, see the [Official Documentation](https://www.algolia.com/doc/guides/managing-results/rules/rules-overview/).",
 		// https://www.algolia.com/doc/api-reference/api-methods/save-rule/#parameters
 		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"index_name": {
 				Type:        schema.TypeString,
 				Required:    true,
@@ -96,7 +100,7 @@ This parameter goes hand in hand with the ` + "`pattern` " + ` parameter. If the
 				Type:     schema.TypeList,
 				Required: true,
 				MaxItems: 1,
-				Description: `Consequence of the Rule. 
+				Description: `Consequence of the Rule.
 At least one of the following object must be used:
 - params
 - promote

--- a/internal/provider/resource_synonyms.go
+++ b/internal/provider/resource_synonyms.go
@@ -28,6 +28,10 @@ func resourceSynonyms() *schema.Resource {
 `,
 		// https://www.algolia.com/doc/api-reference/api-methods/batch-synonyms/
 		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"index_name": {
 				Type:        schema.TypeString,
 				Required:    true,

--- a/internal/provider/resource_virtual_index.go
+++ b/internal/provider/resource_virtual_index.go
@@ -31,6 +31,10 @@ func resourceVirtualIndex() *schema.Resource {
 		},
 		// https://www.algolia.com/doc/api-reference/settings-api-parameters/
 		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,


### PR DESCRIPTION
had issues getting this provider to work with pulumi, and [this comment](https://github.com/pulumi/pulumi-terraform-bridge/pull/2385#issuecomment-2331652952) gave me a hint about ID property not being explicitly set as computed in the provider schema.

I'm not sure if this is the right approach, but it solved the issues I had when trying to use it.