### PR TITLE
Fix Release: Change --rm-dist to --clean

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6.3.0
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           # GitHub sets this automatically


### PR DESCRIPTION
The gorelease version was updated around 02.2023 to use --clean instead of --rm-dist. so that should fix the problem of not being able to release

https://github.com/goreleaser/goreleaser-action/commit/8f389eacd3c1dd4c87483b0212a087fcfc3e966f

Fixes: #246 